### PR TITLE
Updated build script to use hemtt.launch.default instead hemtt.launch

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -28,7 +28,7 @@ git_hash = 8 # Default: 8
 [hemtt.config]
 preset = "Hemtt"
 
-[hemtt.launch]
+[hemtt.launch.default]
 workshop = [
     "450814997", # CBA_A3's Workshop ID
     "463939057", # ACE3


### PR DESCRIPTION
**When merged this pull request will:**
- Updated build script to use hemtt.launch.default instead hemtt.launch